### PR TITLE
Fix require statement for URI library

### DIFF
--- a/lib/websocket/handshake/client.rb
+++ b/lib/websocket/handshake/client.rb
@@ -1,4 +1,4 @@
-require 'URI' unless defined?(URI)
+require 'uri' unless defined?(URI)
 
 module WebSocket
   module Handshake


### PR DESCRIPTION
It should be 'uri' (lowercase) and not 'URI':

```
$ rake
/usr/bin/ruby1.9.1 -S rspec spec/handshake/client_04_spec.rb spec/handshake/client_76_spec.rb spec/handshake/client_75_spec.rb spec/handshake/server_75_spec.rb spec/handshake/server_04_spec.rb spec/handshake/server_76_spec.rb spec/frame/masking_spec.rb spec/frame/outgoing_05_spec.rb spec/frame/incoming_common_spec.rb spec/frame/outgoing_07_spec.rb spec/frame/incoming_04_spec.rb spec/frame/incoming_05_spec.rb spec/frame/incoming_75_spec.rb spec/frame/incoming_03_spec.rb spec/frame/outgoing_03_spec.rb spec/frame/outgoing_04_spec.rb spec/frame/outgoing_common_spec.rb spec/frame/outgoing_75_spec.rb spec/frame/incoming_07_spec.rb -c -f progress
FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Failures:

  1) Client draft 4 handshake should disallow client with invalid challenge
     Failure/Error: Unable to find matching line from backtrace
     LoadError:
       cannot load such file -- URI
     # ./lib/websocket/handshake/client.rb:1:in `<top (required)>'
     # ./spec/handshake/client_04_spec.rb:4:in `block (2 levels) in <top (required)>'
     # ./spec/handshake/client_04_spec.rb:14:in `block (2 levels) in <top (required)>'

[snip other 46 identical failures]

Finished in 0.63676 seconds
883 examples, 47 failures

Failed examples:

[snip list of failures]
rake aborted!
/usr/bin/ruby1.9.1 -S rspec spec/handshake/client_04_spec.rb spec/handshake/client_76_spec.rb spec/handshake/client_75_spec.rb spec/handshake/server_75_spec.rb spec/handshake/server_04_spec.rb spec/handshake/server_76_spec.rb spec/frame/masking_spec.rb spec/frame/outgoing_05_spec.rb spec/frame/incoming_common_spec.rb spec/frame/outgoing_07_spec.rb spec/frame/incoming_04_spec.rb spec/frame/incoming_05_spec.rb spec/frame/incoming_75_spec.rb spec/frame/incoming_03_spec.rb spec/frame/outgoing_03_spec.rb spec/frame/outgoing_04_spec.rb spec/frame/outgoing_common_spec.rb spec/frame/outgoing_75_spec.rb spec/frame/incoming_07_spec.rb -c -f progress failed

Tasks: TOP => default => spec
(See full trace by running task with --trace)
$ sed -i -e '1 s/URI/uri/' lib/websocket/handshake/client.rb 
$ rake
/usr/bin/ruby1.9.1 -S rspec spec/handshake/client_04_spec.rb spec/handshake/client_76_spec.rb spec/handshake/client_75_spec.rb spec/handshake/server_75_spec.rb spec/handshake/server_04_spec.rb spec/handshake/server_76_spec.rb spec/frame/masking_spec.rb spec/frame/outgoing_05_spec.rb spec/frame/incoming_common_spec.rb spec/frame/outgoing_07_spec.rb spec/frame/incoming_04_spec.rb spec/frame/incoming_05_spec.rb spec/frame/incoming_75_spec.rb spec/frame/incoming_03_spec.rb spec/frame/outgoing_03_spec.rb spec/frame/outgoing_04_spec.rb spec/frame/outgoing_common_spec.rb spec/frame/outgoing_75_spec.rb spec/frame/incoming_07_spec.rb -c -f progress
...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 0.5252 seconds
883 examples, 0 failures
```
