### PR TITLE
full handler path for Ruby 1.9.3 autoload

### DIFF
--- a/lib/websocket.rb
+++ b/lib/websocket.rb
@@ -11,7 +11,7 @@ module WebSocket
   ROOT = File.expand_path(File.dirname(__FILE__))
 
   autoload :Frame,     "#{ROOT}/websocket/frame"
-  autoload :Handler,   "#{ROOT}/websocket/handler"
+  autoload :Handler,   "#{ROOT}/websocket/frame/handler"
   autoload :Handshake, "#{ROOT}/websocket/handshake"
 
   # Limit of frame size payload in bytes


### PR DESCRIPTION
Ruby 2.0.0 autoload finds the handler module but 1.9.3 needs the complete path
