### PR TITLE
Modify handling of @code.

### DIFF
--- a/lib/websocket/frame/base.rb
+++ b/lib/websocket/frame/base.rb
@@ -4,7 +4,8 @@ module WebSocket
     class Base
       include ExceptionHandler
 
-      attr_reader :data, :type, :version
+      attr_reader :type, :version
+      attr_accessor :data, :code
 
       # Initialize frame
       # @param args [Hash] Arguments for frame

--- a/lib/websocket/frame/handler/handler05.rb
+++ b/lib/websocket/frame/handler/handler05.rb
@@ -6,9 +6,9 @@ module WebSocket
       class Handler05 < Handler04
 
         def encode_frame
-          if @code
-            @frame.data = Data.new([@code].pack('n') + @frame.data.to_s)
-            @code = nil
+          if @frame.code
+            @frame.data = Data.new([@frame.code].pack('n') + @frame.data.to_s)
+            @frame.code = nil
           end
           super
         end


### PR DESCRIPTION
First of all, I would like to say thank you for your great work!

17469d9a5986dd9cd8d5f9d07b27e9d0d3b2f23b seems to corrupt handling of @code in `handler05.rb`.

For example, the following does not work well:

``` ruby
# 'code' is ignored.
frame = WebSocket::Frame::Outgoing::Client.new(type: :close, code: 1000, version: 13)
```

This is just a simple patch, so please modify in more appropriate way if this patch is not so good.
