### PR TITLE
raname Sec-WebSocket-Origin to Origin in header fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ GET /demo HTTP/1.1\r
 Upgrade: websocket\r
 Connection: Upgrade\r
 Host: example.com\r
-Sec-WebSocket-Origin: http://example.com\r
+Origin: http://example.com\r
 Sec-WebSocket-Version: 13\r
 Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
 \r
@@ -70,7 +70,7 @@ EOF
                 # Connection: Upgrade
                 # Host: example.com
                 # Cookie: SESSIONID=1234
-                # Sec-WebSocket-Origin: http://example.com
+                # Origin: http://example.com
                 # Sec-WebSocket-Version: 13
                 # Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
 

--- a/lib/websocket/handshake/client.rb
+++ b/lib/websocket/handshake/client.rb
@@ -12,7 +12,7 @@ module WebSocket
     #                   # Upgrade: websocket
     #                   # Connection: Upgrade
     #                   # Host: example.com
-    #                   # Sec-WebSocket-Origin: http://example.com
+    #                   # Origin: http://example.com
     #                   # Sec-WebSocket-Version: 13
     #                   # Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
     #

--- a/lib/websocket/handshake/handler/client04.rb
+++ b/lib/websocket/handshake/handler/client04.rb
@@ -23,7 +23,7 @@ module WebSocket
           host += ":#{@handshake.port}" if @handshake.port
           keys << ['Host', host]
           keys += super
-          keys << ['Sec-WebSocket-Origin', @handshake.origin] if @handshake.origin
+          keys << ['Origin', @handshake.origin] if @handshake.origin
           keys << ['Sec-WebSocket-Version', @handshake.version]
           keys << ['Sec-WebSocket-Key', key]
           keys

--- a/lib/websocket/handshake/server.rb
+++ b/lib/websocket/handshake/server.rb
@@ -11,7 +11,7 @@ module WebSocket
     #   Upgrade: websocket\r
     #   Connection: Upgrade\r
     #   Host: example.com\r
-    #   Sec-WebSocket-Origin: http://example.com\r
+    #   Origin: http://example.com\r
     #   Sec-WebSocket-Version: 13\r
     #   Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
     #   \r
@@ -54,7 +54,7 @@ module WebSocket
       #   Upgrade: websocket
       #   Connection: Upgrade
       #   Host: example.com
-      #   Sec-WebSocket-Origin: http://example.com
+      #   Origin: http://example.com
       #   Sec-WebSocket-Version: 13
       #   Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
       #

--- a/spec/support/handshake_requests.rb
+++ b/spec/support/handshake_requests.rb
@@ -54,7 +54,7 @@ GET #{args[:path] || '/demo'}#{"?#{args[:query]}" if args[:query]} HTTP/1.1\r
 Upgrade: websocket\r
 Connection: Upgrade\r
 Host: #{args[:host] || 'example.com'}#{":#{args[:port]}" if args[:port]}\r
-#{(args[:headers] || {}).map{|key, value| "#{key}: #{value}\r\n"}.join('')}Sec-WebSocket-Origin: http://example.com\r
+#{(args[:headers] || {}).map{|key, value| "#{key}: #{value}\r\n"}.join('')}Origin: http://example.com\r
 Sec-WebSocket-Version: #{args[:version] || '4'}\r
 Sec-WebSocket-Key: #{args[:key] || 'dGhlIHNhbXBsZSBub25jZQ=='}\r
 \r


### PR DESCRIPTION
RFC6455 doesn't specify Sec-WebSocket-Origin header in the handshake from client.
http://datatracker.ietf.org/doc/rfc6455/