### PR TITLE
Implemented subprotocol handling for both server and client

### DIFF
--- a/lib/websocket/error.rb
+++ b/lib/websocket/error.rb
@@ -99,6 +99,12 @@ module WebSocket
         end
       end
 
+      class UnsupportedProtocol < ::WebSocket::Error::Handshake
+        def message
+          :unsupported_protocol
+        end
+      end
+
       class InvalidStatusCode < ::WebSocket::Error::Handshake
         def message
           :invalid_status_code

--- a/lib/websocket/handshake/client.rb
+++ b/lib/websocket/handshake/client.rb
@@ -38,16 +38,17 @@ module WebSocket
       #
       # @param [Hash] args Arguments for client
       #
-      # @option args [String]  :host Host of request. Required if no :url param was provided.
-      # @option args [String]  :origin Origin of request. Optional, should be used mostly by browsers. Default: nil
-      # @option args [String]  :path Path of request. Should start with '/'. Default: '/'
-      # @option args [Integer] :port Port of request. Default: nil
-      # @option args [String]  :query. Query for request. Should be in format "aaa=bbb&ccc=ddd"
-      # @option args [Boolean] :secure Defines protocol to use. If true then wss://, otherwise ws://. This option will not change default port - it should be handled by programmer.
-      # @option args [String]  :url URL of request. Must by in format like ws://example.com/path?query=true. Every part of this url will be overriden by more specific arguments.
-      # @option args [String]  :uri Alias to :url
-      # @option args [Integer] :version Version of WebSocket to use. Default: 13 (this is version from RFC)
-      # @option args [Hash]    :headers HTTP headers to use in the handshake
+      # @option args [String]         :host Host of request. Required if no :url param was provided.
+      # @option args [String]         :origin Origin of request. Optional, should be used mostly by browsers. Default: nil
+      # @option args [String]         :path Path of request. Should start with '/'. Default: '/'
+      # @option args [Integer]        :port Port of request. Default: nil
+      # @option args [String]         :query. Query for request. Should be in format "aaa=bbb&ccc=ddd"
+      # @option args [Boolean]        :secure Defines protocol to use. If true then wss://, otherwise ws://. This option will not change default port - it should be handled by programmer.
+      # @option args [String]         :url URL of request. Must by in format like ws://example.com/path?query=true. Every part of this url will be overriden by more specific arguments.
+      # @option args [String]         :uri Alias to :url
+      # @option args [Array<String>]  :protocols An array of supported sub-protocols
+      # @option args [Integer]        :version Version of WebSocket to use. Default: 13 (this is version from RFC)
+      # @option args [Hash]           :headers HTTP headers to use in the handshake
       #
       # @example
       #   Websocket::Handshake::Client.new(url: "ws://example.com/path?query=true")

--- a/lib/websocket/handshake/handler/client75.rb
+++ b/lib/websocket/handshake/handler/client75.rb
@@ -2,6 +2,11 @@ module WebSocket
   module Handshake
     module Handler
       class Client75 < Client
+        # @see WebSocket::Handshake::Base#valid?
+        def valid?
+          super && verify_protocol
+        end
+
         private
 
         # @see WebSocket::Handshake::Handler::Base#handshake_keys
@@ -14,8 +19,18 @@ module WebSocket
           host += ":#{@handshake.port}" if @handshake.port
           keys << ['Host', host]
           keys << ['Origin', @handshake.origin] if @handshake.origin
+          keys << ['WebSocket-Protocol', @handshake.protocols.first] if @handshake.protocols.any?
           keys += super
           keys
+        end
+
+        # Verify if received header WebSocket-Protocol matches with the sent one
+        # @return [Boolean] True if matching. False otherwise(appropriate error is set)
+        def verify_protocol
+          return true if @handshake.protocols.empty?
+          invalid = @handshake.headers['websocket-protocol'].strip != @handshake.protocols.first
+          fail WebSocket::Error::Handshake::UnsupportedProtocol if invalid
+          true
         end
       end
     end

--- a/lib/websocket/handshake/handler/client76.rb
+++ b/lib/websocket/handshake/handler/client76.rb
@@ -6,7 +6,7 @@ module WebSocket
       class Client76 < Client75
         # @see WebSocket::Handshake::Base#valid?
         def valid?
-          super && verify_challenge
+          super && verify_challenge && verify_protocol
         end
 
         private
@@ -92,6 +92,15 @@ module WebSocket
         # Generate third key
         def generate_key3
           [rand(0x100000000)].pack('N') + [rand(0x100000000)].pack('N')
+        end
+
+        # Verify if received header Sec-WebSocket-Protocol matches with the sent one
+        # @return [Boolean] True if matching. False otherwise(appropriate error is set)
+        def verify_protocol
+          return true if @handshake.protocols.empty?
+          invalid = @handshake.headers['sec-websocket-protocol'].strip != @handshake.protocols.first
+          fail WebSocket::Error::Handshake::UnsupportedProtocol if invalid
+          true
         end
       end
     end

--- a/lib/websocket/handshake/handler/server04.rb
+++ b/lib/websocket/handshake/handler/server04.rb
@@ -23,7 +23,7 @@ module WebSocket
             %w(Upgrade websocket),
             %w(Connection Upgrade),
             ['Sec-WebSocket-Accept', signature]
-          ]
+          ] + protocol
         end
 
         # Signature of response, created from client request Sec-WebSocket-Key
@@ -41,6 +41,12 @@ module WebSocket
 
         def key
           @handshake.headers['sec-websocket-key']
+        end
+
+        def protocol
+          return [] unless @handshake.headers.key?('sec-websocket-protocol')
+          protos = @handshake.headers['sec-websocket-protocol'].split(/ *, */) & @handshake.protocols
+          [['Sec-WebSocket-Protocol', protos.first]]
         end
       end
     end

--- a/lib/websocket/handshake/handler/server75.rb
+++ b/lib/websocket/handshake/handler/server75.rb
@@ -16,7 +16,13 @@ module WebSocket
             %w(Connection Upgrade),
             ['WebSocket-Origin', @handshake.headers['origin']],
             ['WebSocket-Location', @handshake.uri]
-          ]
+          ] + protocol
+        end
+
+        def protocol
+          return [] unless @handshake.headers.key?('websocket-protocol')
+          proto = @handshake.headers['websocket-protocol']
+          [['WebSocket-Protocol', @handshake.protocols.include?(proto) ? proto : nil]]
         end
       end
     end

--- a/lib/websocket/handshake/handler/server76.rb
+++ b/lib/websocket/handshake/handler/server76.rb
@@ -28,7 +28,7 @@ module WebSocket
             %w(Connection Upgrade),
             ['Sec-WebSocket-Origin', @handshake.headers['origin']],
             ['Sec-WebSocket-Location', @handshake.uri]
-          ]
+          ] + protocol
         end
 
         # @see WebSocket::Handshake::Handler::Base#finishing_line
@@ -70,6 +70,12 @@ module WebSocket
           fail WebSocket::Error::Handshake::InvalidAuthentication if quotient > 2**32 - 1
 
           quotient
+        end
+
+        def protocol
+          return [] unless @handshake.headers.key?('sec-websocket-protocol')
+          proto = @handshake.headers['sec-websocket-protocol']
+          [['Sec-WebSocket-Protocol', @handshake.protocols.include?(proto) ? proto : nil]]
         end
       end
     end

--- a/lib/websocket/handshake/server.rb
+++ b/lib/websocket/handshake/server.rb
@@ -35,6 +35,7 @@ module WebSocket
       # @param [Hash] args Arguments for server
       #
       # @option args [Boolean] :secure If true then server will use wss:// protocol
+      # @option args [Array<String>] :protocols an array of supported sub-protocols
       #
       # @example
       #   Websocket::Handshake::Server.new(secure: true)

--- a/spec/handshake/client_04_spec.rb
+++ b/spec/handshake/client_04_spec.rb
@@ -17,4 +17,45 @@ RSpec.describe 'Client draft 4 handshake' do
     expect(handshake).not_to be_valid
     expect(handshake.error).to eql(:invalid_handshake_authentication)
   end
+
+  context 'protocol header specified' do
+    let(:handshake) { WebSocket::Handshake::Client.new(uri: 'ws://example.com/demo', origin: 'http://example.com', version: version, protocols: protocols) }
+
+    context 'single protocol requested' do
+      let(:protocols) { %w(binary) }
+
+      it 'returns a valid handshake' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'binary' } }
+        handshake << server_response
+
+        expect(handshake).to be_finished
+        expect(handshake).to be_valid
+      end
+    end
+
+    context 'multiple protocols requested' do
+      let(:protocols) { %w(binary xmpp) }
+
+      it 'returns with a valid handshake' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'xmpp' } }
+        handshake << server_response
+
+        expect(handshake).to be_finished
+        expect(handshake).to be_valid
+      end
+    end
+
+    context 'unsupported protocol requested' do
+      let(:protocols) { %w(binary xmpp) }
+
+      it 'fails with an unsupported protocol error' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'generic' } }
+        handshake << server_response
+
+        expect(handshake).to be_finished
+        expect(handshake).not_to be_valid
+        expect(handshake.error).to eql(:unsupported_protocol)
+      end
+    end
+  end
 end

--- a/spec/handshake/client_75_spec.rb
+++ b/spec/handshake/client_75_spec.rb
@@ -8,4 +8,29 @@ RSpec.describe 'Client draft 75 handshake' do
   let(:server_response) { server_handshake_75(@request_params || {}) }
 
   it_should_behave_like 'all client drafts'
+
+  context 'protocol header specified' do
+    let(:handshake) { WebSocket::Handshake::Client.new(uri: 'ws://example.com/demo', origin: 'http://example.com', version: version, protocols: %w(binary)) }
+
+    context 'supported' do
+      it 'returns a valid handshake' do
+        @request_params = { headers: { 'WebSocket-Protocol' => 'binary' } }
+        handshake << server_response
+
+        expect(handshake).to be_finished
+        expect(handshake).to be_valid
+      end
+    end
+
+    context 'unsupported' do
+      it 'fails with an unsupported protocol error' do
+        @request_params = { headers: { 'WebSocket-Protocol' => 'xmpp' } }
+        handshake << server_response
+
+        expect(handshake).to be_finished
+        expect(handshake).not_to be_valid
+        expect(handshake.error).to eql(:unsupported_protocol)
+      end
+    end
+  end
 end

--- a/spec/handshake/client_76_spec.rb
+++ b/spec/handshake/client_76_spec.rb
@@ -17,4 +17,29 @@ RSpec.describe 'Client draft 76 handshake' do
     expect(handshake).not_to be_valid
     expect(handshake.error).to eql(:invalid_handshake_authentication)
   end
+
+  context 'protocol header specified' do
+    let(:handshake) { WebSocket::Handshake::Client.new(uri: 'ws://example.com/demo', origin: 'http://example.com', version: version, protocols: %w(binary)) }
+
+    context 'supported' do
+      it 'returns a valid handshake' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'binary' } }
+        handshake << server_response
+
+        expect(handshake).to be_finished
+        expect(handshake).to be_valid
+      end
+    end
+
+    context 'unsupported' do
+      it 'fails with an unsupported protocol error' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'xmpp' } }
+        handshake << server_response
+
+        expect(handshake).to be_finished
+        expect(handshake).not_to be_valid
+        expect(handshake.error).to eql(:unsupported_protocol)
+      end
+    end
+  end
 end

--- a/spec/handshake/server_04_spec.rb
+++ b/spec/handshake/server_04_spec.rb
@@ -15,4 +15,35 @@ RSpec.describe 'Server draft 04 handshake' do
     expect(handshake).not_to be_valid
     expect(handshake.error).to eql(:invalid_handshake_authentication)
   end
+
+  context 'protocol header specified' do
+    let(:handshake) { WebSocket::Handshake::Server.new(protocols: %w(binary xmpp)) }
+
+    context 'single protocol requested' do
+      it 'returns with the same protocol' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'binary' } }
+        handshake << client_request
+
+        expect(handshake.to_s).to match('Sec-WebSocket-Protocol: binary')
+      end
+    end
+
+    context 'multiple protocols requested' do
+      it 'returns with the first supported protocol' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'xmpp, binary' } }
+        handshake << client_request
+
+        expect(handshake.to_s).to match('Sec-WebSocket-Protocol: xmpp')
+      end
+    end
+
+    context 'unsupported protocol requested' do
+      it 'reutrns with an empty protocol header' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'generic' } }
+        handshake << client_request
+
+        expect(handshake.to_s).to match("Sec-WebSocket-Protocol: \r\n")
+      end
+    end
+  end
 end

--- a/spec/handshake/server_75_spec.rb
+++ b/spec/handshake/server_75_spec.rb
@@ -8,4 +8,26 @@ RSpec.describe 'Server draft 75 handshake' do
   let(:server_response) { server_handshake_75(@request_params || {}) }
 
   it_should_behave_like 'all server drafts'
+
+  context 'protocol header specified' do
+    let(:handshake) { WebSocket::Handshake::Server.new(protocols: %w(binary)) }
+
+    context 'supported' do
+      it 'returns with the same protocol' do
+        @request_params = { headers: { 'WebSocket-Protocol' => 'binary' } }
+        handshake << client_request
+
+        expect(handshake.to_s).to match('WebSocket-Protocol: binary')
+      end
+    end
+
+    context 'unsupported' do
+      it 'returns with an empty protocol header' do
+        @request_params = { headers: { 'WebSocket-Protocol' => 'xmpp' } }
+        handshake << client_request
+
+        expect(handshake.to_s).to match("WebSocket-Protocol: \r\n")
+      end
+    end
+  end
 end

--- a/spec/handshake/server_76_spec.rb
+++ b/spec/handshake/server_76_spec.rb
@@ -43,4 +43,26 @@ RSpec.describe 'Server draft 76 handshake' do
     expect(handshake).not_to be_valid
     expect(handshake.error).to eql(:invalid_handshake_authentication)
   end
+
+  context 'protocol header specified' do
+    let(:handshake) { WebSocket::Handshake::Server.new(protocols: %w(binary)) }
+
+    context 'supported' do
+      it 'returns with the same protocol' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'binary' } }
+        handshake << client_request
+
+        expect(handshake.to_s).to match('Sec-WebSocket-Protocol: binary')
+      end
+    end
+
+    context 'unsupported' do
+      it 'returns with an empty protocol header' do
+        @request_params = { headers: { 'Sec-WebSocket-Protocol' => 'xmpp' } }
+        handshake << client_request
+
+        expect(handshake.to_s).to match("Sec-WebSocket-Protocol: \r\n")
+      end
+    end
+  end
 end

--- a/spec/support/handshake_requests.rb
+++ b/spec/support/handshake_requests.rb
@@ -14,7 +14,7 @@ def server_handshake_75(args = {})
 HTTP/1.1 101 Web Socket Protocol Handshake\r
 Upgrade: WebSocket\r
 Connection: Upgrade\r
-WebSocket-Origin: http://example.com\r
+#{(args[:headers] || {}).map { |key, value| "#{key}: #{value}\r\n" }.join('')}WebSocket-Origin: http://example.com\r
 WebSocket-Location: ws#{args[:secure] ? 's' : ''}://#{args[:host] || 'example.com'}#{":#{args[:port]}" if args[:port]}#{args[:path] || '/demo'}\r
 \r
   EOF
@@ -40,7 +40,7 @@ def server_handshake_76(args = {})
 HTTP/1.1 101 WebSocket Protocol Handshake\r
 Upgrade: WebSocket\r
 Connection: Upgrade\r
-Sec-WebSocket-Origin: http://example.com\r
+#{(args[:headers] || {}).map { |key, value| "#{key}: #{value}\r\n" }.join('')}Sec-WebSocket-Origin: http://example.com\r
 Sec-WebSocket-Location: ws#{args[:secure] ? 's' : ''}://#{args[:host] || 'example.com'}#{":#{args[:port]}" if args[:port]}#{args[:path] || '/demo'}\r
 \r
 #{args[:challenge] || "8jKS'y:G*Co,Wxa-"}
@@ -66,7 +66,7 @@ def server_handshake_04(args = {})
 HTTP/1.1 101 Switching Protocols\r
 Upgrade: websocket\r
 Connection: Upgrade\r
-Sec-WebSocket-Accept: #{args[:accept] || 's3pPLMBiTxaQ9kYGzzhZRbK+xOo='}\r
+#{(args[:headers] || {}).map { |key, value| "#{key}: #{value}\r\n" }.join('')}Sec-WebSocket-Accept: #{args[:accept] || 's3pPLMBiTxaQ9kYGzzhZRbK+xOo='}\r
 \r
   EOF
 end


### PR DESCRIPTION
This is an optional feature requested by some WebSocket-based clients such as noVNC or SPICE-HTML5. The list of supported protocols can be specified by passing an array of strings under the `:protocols` hash key. If no protocols are specified or an empty array is passed, the server/client won't send the header.

The protocol array is required even for the hixie drafts that have no support for multiple subprotocols. In such case the first element of the array is used for comparison.

References:
https://tools.ietf.org/html/rfc6455#section-11.3.4
https://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-75#section-8.5
https://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76#section-8.7

Resolves #26 