### PR TITLE
Get tests passing with frozen-string-literals enabled.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 group :development do
   gem 'rake'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.7'
 
   # Use same version as Code Climate for consistency with CI
   # https://github.com/codeclimate/codeclimate-rubocop/blob/master/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/lib/websocket.rb
+++ b/lib/websocket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WebSocket protocol implementation in Ruby
 # This module does not provide a WebSocket server or client, but is made for using
 # in http servers or clients to provide WebSocket support.

--- a/lib/websocket/error.rb
+++ b/lib/websocket/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   class Error < RuntimeError
     class Frame < ::WebSocket::Error

--- a/lib/websocket/exception_handler.rb
+++ b/lib/websocket/exception_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module ExceptionHandler
     attr_accessor :error

--- a/lib/websocket/frame.rb
+++ b/lib/websocket/frame.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     autoload :Base,     "#{::WebSocket::ROOT}/websocket/frame/base"

--- a/lib/websocket/frame/base.rb
+++ b/lib/websocket/frame/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     # @abstract Subclass and override to implement custom frames

--- a/lib/websocket/frame/data.rb
+++ b/lib/websocket/frame/data.rb
@@ -11,7 +11,7 @@ module WebSocket
 
       # Convert all arguments to ASCII-8BIT for easier traversing
       def convert_args(args)
-        args.each { |arg| arg.force_encoding('ASCII-8BIT') }
+        args.collect { |arg| arg.dup.force_encoding('ASCII-8BIT') }
       end
 
       # Extract mask from 4 first bytes according to spec

--- a/lib/websocket/frame/data.rb
+++ b/lib/websocket/frame/data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     class Data < String

--- a/lib/websocket/frame/handler.rb
+++ b/lib/websocket/frame/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     module Handler

--- a/lib/websocket/frame/handler/base.rb
+++ b/lib/websocket/frame/handler/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     module Handler

--- a/lib/websocket/frame/handler/handler03.rb
+++ b/lib/websocket/frame/handler/handler03.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'securerandom'
 

--- a/lib/websocket/frame/handler/handler03.rb
+++ b/lib/websocket/frame/handler/handler03.rb
@@ -89,14 +89,14 @@ module WebSocket
         def encode_header
           mask = @frame.outgoing_masking? ? 0b10000000 : 0b00000000
 
-          output = ''
+          output = String.new('')
           output << (type_to_opcode(@frame.type) | (fin ? 0b10000000 : 0b00000000)) # since more, rsv1-3 are 0 and 0x80 for Draft 4
           output << encode_payload_length(@frame.data.size, mask)
           output
         end
 
         def encode_payload_length(length, mask)
-          output = ''
+          output = String.new('')
           if length <= 125
             output << (length | mask) # since rsv4 is 0
           elsif length < 65_536 # write 2 byte length
@@ -197,7 +197,7 @@ module WebSocket
         end
 
         def decode_continuation_frame(application_data, frame_type)
-          @application_data_buffer ||= ''
+          @application_data_buffer ||= String.new('')
           @application_data_buffer << application_data
           @frame_type ||= frame_type
         end

--- a/lib/websocket/frame/handler/handler04.rb
+++ b/lib/websocket/frame/handler/handler04.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 module WebSocket
   module Frame

--- a/lib/websocket/frame/handler/handler05.rb
+++ b/lib/websocket/frame/handler/handler05.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 module WebSocket
   module Frame

--- a/lib/websocket/frame/handler/handler07.rb
+++ b/lib/websocket/frame/handler/handler07.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 module WebSocket
   module Frame

--- a/lib/websocket/frame/handler/handler75.rb
+++ b/lib/websocket/frame/handler/handler75.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 module WebSocket
   module Frame

--- a/lib/websocket/frame/incoming.rb
+++ b/lib/websocket/frame/incoming.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     # Construct or parse incoming WebSocket Frame.

--- a/lib/websocket/frame/incoming/client.rb
+++ b/lib/websocket/frame/incoming/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     class Incoming

--- a/lib/websocket/frame/incoming/server.rb
+++ b/lib/websocket/frame/incoming/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     class Incoming

--- a/lib/websocket/frame/outgoing.rb
+++ b/lib/websocket/frame/outgoing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     # Construct or parse incoming WebSocket Frame.

--- a/lib/websocket/frame/outgoing/client.rb
+++ b/lib/websocket/frame/outgoing/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     class Outgoing

--- a/lib/websocket/frame/outgoing/server.rb
+++ b/lib/websocket/frame/outgoing/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     class Outgoing

--- a/lib/websocket/handshake.rb
+++ b/lib/websocket/handshake.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     autoload :Base,    "#{::WebSocket::ROOT}/websocket/handshake/base"

--- a/lib/websocket/handshake/base.rb
+++ b/lib/websocket/handshake/base.rb
@@ -16,7 +16,7 @@ module WebSocket
         @state = :new
         @handler = nil
 
-        @data = ''
+        @data = String.new('')
         @headers ||= {}
         @protocols ||= []
       end
@@ -62,7 +62,7 @@ module WebSocket
       # @example
       #   @handshake.uri #=> "ws://example.com/path?query=true"
       def uri
-        uri =  secure ? 'wss://' : 'ws://'
+        uri =  String.new(secure ? 'wss://' : 'ws://')
         uri << host
         uri << ":#{port}" if port
         uri << path

--- a/lib/websocket/handshake/base.rb
+++ b/lib/websocket/handshake/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     # @abstract Subclass and override to implement custom handshakes

--- a/lib/websocket/handshake/client.rb
+++ b/lib/websocket/handshake/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 module WebSocket

--- a/lib/websocket/handshake/handler.rb
+++ b/lib/websocket/handshake/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     module Handler

--- a/lib/websocket/handshake/handler/base.rb
+++ b/lib/websocket/handshake/handler/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     module Handler

--- a/lib/websocket/handshake/handler/client.rb
+++ b/lib/websocket/handshake/handler/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     module Handler

--- a/lib/websocket/handshake/handler/client01.rb
+++ b/lib/websocket/handshake/handler/client01.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/md5'
 
 module WebSocket

--- a/lib/websocket/handshake/handler/client04.rb
+++ b/lib/websocket/handshake/handler/client04.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/sha1'
 require 'base64'
 

--- a/lib/websocket/handshake/handler/client11.rb
+++ b/lib/websocket/handshake/handler/client11.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     module Handler

--- a/lib/websocket/handshake/handler/client75.rb
+++ b/lib/websocket/handshake/handler/client75.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     module Handler

--- a/lib/websocket/handshake/handler/client76.rb
+++ b/lib/websocket/handshake/handler/client76.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/md5'
 
 module WebSocket

--- a/lib/websocket/handshake/handler/server.rb
+++ b/lib/websocket/handshake/handler/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     module Handler

--- a/lib/websocket/handshake/handler/server04.rb
+++ b/lib/websocket/handshake/handler/server04.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/sha1'
 require 'base64'
 

--- a/lib/websocket/handshake/handler/server75.rb
+++ b/lib/websocket/handshake/handler/server75.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     module Handler

--- a/lib/websocket/handshake/handler/server76.rb
+++ b/lib/websocket/handshake/handler/server76.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/md5'
 
 module WebSocket

--- a/lib/websocket/handshake/server.rb
+++ b/lib/websocket/handshake/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     # Construct or parse a server WebSocket handshake.

--- a/lib/websocket/nice_inspect.rb
+++ b/lib/websocket/nice_inspect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module NiceInspect
     # Recreate inspect as #to_s will be overwritten

--- a/lib/websocket/version.rb
+++ b/lib/websocket/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   VERSION = '1.2.5'.freeze
 end

--- a/spec/frame/incoming_03_spec.rb
+++ b/spec/frame/incoming_03_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/incoming_04_spec.rb
+++ b/spec/frame/incoming_04_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/incoming_05_spec.rb
+++ b/spec/frame/incoming_05_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/incoming_07_spec.rb
+++ b/spec/frame/incoming_07_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/incoming_75_spec.rb
+++ b/spec/frame/incoming_75_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/incoming_common_spec.rb
+++ b/spec/frame/incoming_common_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/masking_spec.rb
+++ b/spec/frame/masking_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/outgoing_03_spec.rb
+++ b/spec/frame/outgoing_03_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/outgoing_04_spec.rb
+++ b/spec/frame/outgoing_04_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/outgoing_05_spec.rb
+++ b/spec/frame/outgoing_05_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/outgoing_07_spec.rb
+++ b/spec/frame/outgoing_07_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/outgoing_75_spec.rb
+++ b/spec/frame/outgoing_75_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/frame/outgoing_common_spec.rb
+++ b/spec/frame/outgoing_common_spec.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/handshake/client_04_spec.rb
+++ b/spec/handshake/client_04_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Client draft 4 handshake' do

--- a/spec/handshake/client_11_spec.rb
+++ b/spec/handshake/client_11_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Client draft 11 handshake' do

--- a/spec/handshake/client_75_spec.rb
+++ b/spec/handshake/client_75_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Client draft 75 handshake' do

--- a/spec/handshake/client_76_spec.rb
+++ b/spec/handshake/client_76_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Client draft 76 handshake' do

--- a/spec/handshake/server_04_spec.rb
+++ b/spec/handshake/server_04_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Server draft 04 handshake' do

--- a/spec/handshake/server_75_spec.rb
+++ b/spec/handshake/server_75_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Server draft 75 handshake' do

--- a/spec/handshake/server_76_spec.rb
+++ b/spec/handshake/server_76_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Server draft 76 handshake' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec'
 
 require 'websocket'

--- a/spec/support/all_client_drafts.rb
+++ b/spec/support/all_client_drafts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples_for 'all client drafts' do
   def validate_request
     expect(handshake.to_s).to eql(client_request)

--- a/spec/support/all_server_drafts.rb
+++ b/spec/support/all_server_drafts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webrick'
 
 RSpec.shared_examples_for 'all server drafts' do

--- a/spec/support/frames_base.rb
+++ b/spec/support/frames_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Frame
     class Base

--- a/spec/support/handshake_requests.rb
+++ b/spec/support/handshake_requests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def client_handshake_75(args = {})
   <<-EOF
 GET #{args[:path] || '/demo'}#{"?#{args[:query]}" if args[:query]} HTTP/1.1\r

--- a/spec/support/incoming_frames.rb
+++ b/spec/support/incoming_frames.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples_for 'valid_incoming_frame' do
   let(:decoded_text_array) { Array(decoded_text) }
   let(:frame_type_array) { Array(frame_type) }

--- a/spec/support/outgoing_frames.rb
+++ b/spec/support/outgoing_frames.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples_for 'valid_outgoing_frame' do
   it 'is outgoing frame' do
     expect(subject.class).to be WebSocket::Frame::Outgoing

--- a/spec/support/overwrites.rb
+++ b/spec/support/overwrites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebSocket
   module Handshake
     class Base

--- a/websocket.gemspec
+++ b/websocket.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -*- encoding: utf-8 -*-
 
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)


### PR DESCRIPTION
These changes ensure that all string literals can be frozen (as per the optional feature in MRI 2.3 and onwards). I would recommend adding the following to your `.travis.yml` file to ensure regressions aren't introduced:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

This will add the flag when the tests are run on MRI 2.4 or newer (while the feature was introduced in 2.3, it doesn't seem to work reliably until 2.4). Please note: this does require the latest commits for RSpec (particularly: rspec-core and rspec-support).