### PR TITLE
Travis: RVM does the gem update --system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,4 @@ matrix:
     - rvm: jruby-head
 
 before_install:
-  - gem update --system
   - gem update bundler


### PR DESCRIPTION
RVM nowadays does the `gem update --system` during install, as a precaution.

This allows us to skip that step.