### PR TITLE
Make handshake server resilient to non-string Rack env keys.

### DIFF
--- a/lib/websocket/handshake/server.rb
+++ b/lib/websocket/handshake/server.rb
@@ -71,7 +71,7 @@ module WebSocket
       # @example
       #   @handshake.from_rack(env)
       def from_rack(env)
-        @headers = env.select { |key, _value| key.start_with? 'HTTP_' }.each_with_object({}) do |tuple, memo|
+        @headers = env.select { |key, _value| key.to_s.start_with? 'HTTP_' }.each_with_object({}) do |tuple, memo|
           key, value = tuple
           memo[key.gsub(/\AHTTP_/, '').tr('_', '-').downcase] = value
         end

--- a/spec/support/all_server_drafts.rb
+++ b/spec/support/all_server_drafts.rb
@@ -92,7 +92,8 @@ RSpec.shared_examples_for 'all server drafts' do
     rest = client_request.slice((request.to_s.length..-1))
 
     handshake.from_rack(request.meta_vars.merge(
-                          'rack.input' => StringIO.new(rest)
+                          'rack.input' => StringIO.new(rest),
+                          :random_key => :random_value
     ))
     validate_request
   end


### PR DESCRIPTION
The Rack specification doesn't guarantee that keys inside the Rack env
will always be strings
(http://www.rubydoc.info/github/rack/rack/master/file/SPEC).

Call #to_s on keys before calling #start_with? on them.

I think the test could be clearer, open to suggestions!