### PR TITLE
chore: Avoid YARD warnings

### DIFF
--- a/lib/websocket/exception_handler.rb
+++ b/lib/websocket/exception_handler.rb
@@ -14,7 +14,7 @@ module WebSocket
       # @param [String] method_name Name of method that should be wrapped and rescued
       # @param [Hash] options Options for rescue
       #
-      # @options options [Any] :return Value that should be returned instead of raised error
+      # @option options [Any] :return Value that should be returned instead of raised error
       def rescue_method(method_name, options = {})
         define_method "#{method_name}_with_rescue" do |*args|
           begin

--- a/lib/websocket/handshake/handler/client76.rb
+++ b/lib/websocket/handshake/handler/client76.rb
@@ -71,7 +71,7 @@ module WebSocket
         NOISE_CHARS = ("\x21".."\x2f").to_a + ("\x3a".."\x7e").to_a
 
         # Generate Sec-WebSocket-Key1 and Sec-WebSocket-Key2
-        # @param [String] name of key. Will be used to set number variable needed later. Valid values: key1, key2
+        # @param key [String] name of key. Will be used to set number variable needed later. Valid values: key1, key2
         # @return [String] generated key
         def generate_key(key)
           spaces = rand(1..12)


### PR DESCRIPTION
This PR fixes the last YARD warnings:

  - Spell the `@option` parameter correctly
  - Mention the name of the parameter

## Screenshot of the result

<img width="916" alt="image" src="https://user-images.githubusercontent.com/211/75609368-3e38d780-5b08-11ea-8418-fb43dbfbd5ec.png">
