### PR TITLE
Initialize instance variables to avoid ruby -w warnigs

### DIFF
--- a/lib/websocket/frame/data.rb
+++ b/lib/websocket/frame/data.rb
@@ -5,6 +5,7 @@ module WebSocket
     class Data < String
       def initialize(*args)
         super(*convert_args(args))
+        @masking_key = nil
       end
 
       def <<(*args)

--- a/lib/websocket/frame/handler/handler03.rb
+++ b/lib/websocket/frame/handler/handler03.rb
@@ -20,6 +20,11 @@ module WebSocket
         # Hash of frame opcodes and it's names
         FRAME_TYPES_INVERSE = FRAME_TYPES.invert.freeze
 
+        def initialize(frame)
+          super
+          @application_data_buffer = nil
+        end
+
         # @see WebSocket::Frame::Base#supported_frames
         def supported_frames
           %i[text binary close ping pong]


### PR DESCRIPTION
When WebSocket is used as a client in a Ruby script running in the warning mode (`ruby -w`), it would print the following warnings:

```
./bundle/ruby/2.6.0/gems/websocket-1.2.8/lib/websocket/frame/handler/handler03.rb:146: warning: instance variable @application_data_buffer not initialized
./bundle/ruby/2.6.0/gems/websocket-1.2.8/lib/websocket/frame/data.rb:33: warning: instance variable @masking_key not initialized
```

These warnings can be easily fixed by initializing instance variables in the constructor.