### PR TITLE
Add webrick depdendency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'http://rubygems.org'
 group :development do
   gem 'rake'
   gem 'rspec', '~> 3.7'
+  gem 'webrick'
 
   # Use same version as Code Climate for consistency with CI
   # https://github.com/codeclimate/codeclimate-rubocop/blob/master/Gemfile.lock


### PR DESCRIPTION
This is required since Ruby 3.0, because it was completely removed from StdLib.