### PR TITLE
Force testing on 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
           - jruby
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Looks like 3.0 is converted to 3 in YAML, and we always want to check 3.0