### PR TITLE
Do not use base64

### DIFF
--- a/lib/websocket/handshake/handler/client04.rb
+++ b/lib/websocket/handshake/handler/client04.rb
@@ -34,13 +34,13 @@ module WebSocket
         # Sec-WebSocket-Key value
         # @return [String] key
         def key
-          @key ||= Base64.encode64((1..16).map { rand(255).chr } * '').strip
+          @key ||= [(1..16).map { rand(255).chr } * ''].pack('m').strip
         end
 
         # Value of Sec-WebSocket-Accept that should be delivered back by server
         # @return [Sering] accept
         def accept
-          @accept ||= Base64.encode64(Digest::SHA1.digest(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')).strip
+          @accept ||= [Digest::SHA1.digest(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')].pack('m').strip
         end
 
         # Verify if received header Sec-WebSocket-Accept matches generated one.

--- a/lib/websocket/handshake/handler/server04.rb
+++ b/lib/websocket/handshake/handler/server04.rb
@@ -33,7 +33,7 @@ module WebSocket
         def signature
           return unless key
           string_to_sign = "#{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-          Base64.encode64(Digest::SHA1.digest(string_to_sign)).chomp
+          [Digest::SHA1.digest(string_to_sign)].pack('m').chomp
         end
 
         def verify_key


### PR DESCRIPTION
Ruby 3.4.0 will bundle base64 as a gem. This means `websocket.gemspec` need to explicitly depend on the gem by `gem 'base64'`.

Currently, this gem only uses `Base64.encode64`. So, how about use `Array#pack` instead of the base64 gem?

If you prefer to add `gem 'base64'` to gemspec, let me know. I will be happy to change this PR.