### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/websocket.gemspec
+++ b/websocket.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = 'Universal Ruby library to handle WebSocket protocol'
   s.license     = 'MIT'
 
-  s.files         = `git ls-files`.split("\n").grep_v(/^spec/)
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(spec/|\.)}) }
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 

--- a/websocket.gemspec
+++ b/websocket.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |s|
   s.description = 'Universal Ruby library to handle WebSocket protocol'
   s.license     = 'MIT'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files         = `git ls-files`.split("\n").grep_v(/^spec/)
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 


### PR DESCRIPTION
Here's a patch that excludes spec files from the gem package.

With this patch, the .gem file size diminishes from 28672 bytes to 23040 bytes on current master.