### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/websocket

### DIFF
--- a/websocket.gemspec
+++ b/websocket.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.0'
+
+  s.metadata['changelog_uri'] = s.homepage + '/blob/master/CHANGELOG.md'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/websocket which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/