### PR TITLE
Include invalid status code when raising handshake error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge
 
+- include invalid status code when raising handshake error
+
 ## 1.2.11
 
 - remove unused base64 require that would cause issues in Ruby 3.4

--- a/lib/websocket/error.rb
+++ b/lib/websocket/error.rb
@@ -108,6 +108,12 @@ module WebSocket
       end
 
       class InvalidStatusCode < ::WebSocket::Error::Handshake
+        attr_reader :invalid_status_code
+
+        def initialize(invalid_status_code)
+          @invalid_status_code = invalid_status_code
+        end
+
         def message
           :invalid_status_code
         end

--- a/lib/websocket/handshake/client.rb
+++ b/lib/websocket/handshake/client.rb
@@ -123,7 +123,14 @@ module WebSocket
         line_parts = line.match(FIRST_LINE)
         raise WebSocket::Error::Handshake::InvalidHeader unless line_parts
         status = line_parts[1]
-        raise WebSocket::Error::Handshake::InvalidStatusCode unless status == '101'
+
+        # The signature for the error doesn't take the message as the first
+        # argument, but rather the status code. So this should use the
+        # initializer to create the error.
+        #
+        # rubocop:disable Style/RaiseArgs
+        raise WebSocket::Error::Handshake::InvalidStatusCode.new(status) unless status == '101'
+        # rubocop:enable Style/RaiseArgs
       end
     end
   end


### PR DESCRIPTION
The desired outcome of this PR is to include the actual failed status code when the `InvalidStatusCode` error is raised during the websocket handshake. We've encountered several instances where websocket connections fail during the handshake with `:invalid_status_code`. However, when server logs are unavailable, it can be difficult to determine what the actual problem is to resolve it.

In this PR, I've updated the error class to include the invalid status code as a member variable so that we can inspect the status code when handling this exception in our application.

Please let me know if this is a change you are amenable to, and if you have any guidance or suggestions for how to improve the PR itself.

Thanks! 